### PR TITLE
ベンチマークの結果に中央値を使うように

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - improve-measure-data
+      - improve-measure
   schedule:
     # JST で毎週土曜 12:00 (UTC で毎週土曜 3:00) に実行
     - cron: '0 3 * * SAT'

--- a/benchmark/fps.ts
+++ b/benchmark/fps.ts
@@ -1,6 +1,6 @@
 import { chromium } from 'playwright';
 import { log } from './helper/log';
-import { mean } from './helper/statistics';
+import { median } from './helper/statistics';
 
 // mackerel に送信する際に利用する現在時刻 (秒)
 const time = process.env.TIME === undefined ? Math.round(Date.now() / 1000) : +process.env.TIME;
@@ -73,7 +73,7 @@ async function measureFPS() {
 
 function printReportForMackerel(measurements: Measurement[]) {
   const name = 'fps.fps';
-  const value = mean(measurements.map((measurement) => measurement.fps));
+  const value = median(measurements.map((measurement) => measurement.fps));
   console.log(`${name} ${value} ${time}`);
 }
 

--- a/benchmark/helper/MemoryUsageMonitor.ts
+++ b/benchmark/helper/MemoryUsageMonitor.ts
@@ -1,4 +1,4 @@
-import { mean } from './statistics';
+import { median } from './statistics';
 
 type MeasurementDiff = {
   // name: BytesPerSecond
@@ -47,19 +47,19 @@ function isNumber(value: any): value is number {
   return typeof value === 'number';
 }
 
-function meanMeasurementDiffs(measurementDiffs: MeasurementDiff[]): MeasurementDiff {
+function medianMeasurementDiffs(measurementDiffs: MeasurementDiff[]): MeasurementDiff {
   return {
-    'memory-usage.all': mean(measurementDiffs.map((diff) => diff['memory-usage.all'])),
-    'memory-usage.breakdown.JavaScript': mean(
+    'memory-usage.all': median(measurementDiffs.map((diff) => diff['memory-usage.all'])),
+    'memory-usage.breakdown.JavaScript': median(
       measurementDiffs.map((diff) => diff['memory-usage.breakdown.JavaScript']).filter(isNumber),
     ),
-    'memory-usage.breakdown.DOM': mean(
+    'memory-usage.breakdown.DOM': median(
       measurementDiffs.map((diff) => diff['memory-usage.breakdown.DOM']).filter(isNumber),
     ),
-    'memory-usage.breakdown.Shared': mean(
+    'memory-usage.breakdown.Shared': median(
       measurementDiffs.map((diff) => diff['memory-usage.breakdown.Shared']).filter(isNumber),
     ),
-    'memory-usage.breakdown.Canvas': mean(
+    'memory-usage.breakdown.Canvas': median(
       measurementDiffs.map((diff) => diff['memory-usage.breakdown.Canvas']).filter(isNumber),
     ),
   };
@@ -73,7 +73,7 @@ export function generateReport(measurementWithTimes: MeasurementWithTime[]): Mea
     const diff = diffMeasurements(measurementWithTime1, measurementWithTime2);
     measurementDiffs.push(diff);
   }
-  return meanMeasurementDiffs(measurementDiffs);
+  return medianMeasurementDiffs(measurementDiffs);
 }
 
 /**

--- a/benchmark/helper/statistics.ts
+++ b/benchmark/helper/statistics.ts
@@ -1,3 +1,10 @@
 export function mean(array: number[]) {
   return array.reduce((a, b) => a + b, 0) / array.length;
 }
+
+export function median(array: number[]): number {
+  if (array.length === 0) return 0;
+  if (array.length === 1) return array[0];
+  if (array.length % 2 === 0) return (array[array.length / 2 - 1] + array[array.length / 2]) / 2;
+  return array[Math.floor(array.length / 2)];
+}

--- a/benchmark/memory.ts
+++ b/benchmark/memory.ts
@@ -32,7 +32,7 @@ async function measureMemory(): Promise<MeasurementWithTime[]> {
   const measurement = await performance.measureUserAgentSpecificMemory!();
   const time = performance.now();
   measurementWithTimes.push({ time, measurement });
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 10; i++) {
     await wait(10 * 1000); // 10 秒間待機
     const measurement = await performance.measureUserAgentSpecificMemory!();
     const time = performance.now();


### PR DESCRIPTION
ref: #225 

結構外れ値が取れることが多くて、sample の平均だと外れ値の影響を受けやすかったため、中央値を使ってみる。